### PR TITLE
Change the name of grimoire module (now grimoire_elk).

### DIFF
--- a/mordred.py
+++ b/mordred.py
@@ -35,11 +35,11 @@ from datetime import datetime, timedelta
 
 from urllib.parse import urljoin
 
-from grimoire.arthur import (feed_backend, enrich_backend, get_ocean_backend,
+from grimoire_elk.arthur import (feed_backend, enrich_backend, get_ocean_backend,
                              load_identities, do_studies,
                              refresh_projects, refresh_identities)
-from grimoire.panels import import_dashboard, get_dashboard_name
-from grimoire.utils import get_connectors, get_connector_from_name, get_elastic
+from grimoire_elk.panels import import_dashboard, get_dashboard_name
+from grimoire_elk.utils import get_connectors, get_connector_from_name, get_elastic
 
 from sortinghat import api
 from sortinghat.cmd.affiliate import Affiliate


### PR DESCRIPTION
This would make mordred to work with the new grimoire_elk module (please, accept this PR after accepting the one for grimoireELK, whcih implements that change).

Sidenote: when trying to run modred with the current GrimoireELK (master branch), I found that even for running `--help` there seems to be an error:

```
$ python mordred.py --help
Traceback (most recent call last):
  File "mordred.py", line 41, in <module>
    from grimoire_elk.panels import import_dashboard, get_dashboard_name
ImportError: cannot import name 'get_dashboard_name'
```