### PR TITLE
Improve the Exception handling for threads by using queues. Fix T2031

### DIFF
--- a/bin/mordred
+++ b/bin/mordred
@@ -28,9 +28,13 @@ import configparser
 import logging
 import os
 import sys
+import traceback
 
 sys.path.insert(1, '.')
-from mordred.mordred import Mordred, ElasticSearchError
+
+from mordred.error import ElasticSearchError
+from mordred.error import DataCollectionError
+from mordred.mordred import Mordred
 
 
 SLEEPFOR_ERROR = """Error: You may be Arthur, King of the Britons. But you still """ + \
@@ -144,3 +148,15 @@ if __name__ == '__main__':
         s = 'Error: %s\n' % str(e)
         sys.stderr.write(s)
         sys.exit(1)
+    except:
+        logger.info("OTHER EXCEPTION") #FIXME
+        var = traceback.format_exc()
+        logger.error("Unexpected error. See the traceback below")
+        logger.error(var)
+        sys.exit(1)
+    """except DataCollectionError as e:
+        logger.info("DataCollectionError") #FIXME
+        logger.error(str(e))
+        var = traceback.format_exc()
+        logger.error(var)
+        pass"""

--- a/bin/mordred
+++ b/bin/mordred
@@ -154,9 +154,3 @@ if __name__ == '__main__':
         logger.error("Unexpected error. See the traceback below")
         logger.error(var)
         sys.exit(1)
-    """except DataCollectionError as e:
-        logger.info("DataCollectionError") #FIXME
-        logger.error(str(e))
-        var = traceback.format_exc()
-        logger.error(var)
-        pass"""

--- a/mordred/error.py
+++ b/mordred/error.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Luis Cañas-Díaz <lcanas@bitergia.com>
+
+class DataCollectionError(Exception):
+    """Exception raise for error calling feed_backend method
+    """
+    def __init__(self, expression):
+        self.expression = expression
+
+class ElasticSearchError(Exception):
+    """Exception raised for errors in the list of backends
+    """
+    def __init__(self, expression):
+        self.expression = expression
+
+class DataEnrichmentError(Exception):
+    """Exception raised for error calling the enrich_backend method
+    """
+    def __init__(self, expression):
+        self.expression = expression

--- a/mordred/task.py
+++ b/mordred/task.py
@@ -49,7 +49,7 @@ class Task():
         """
         return True
 
-    def run(self):
+    def execute(self):
         """ Execute the Task """
         logger.debug("A bored task. It does nothing!")
 

--- a/mordred/task_collection.py
+++ b/mordred/task_collection.py
@@ -42,7 +42,7 @@ class TaskRawDataCollection(Task):
         # This will be options in next iteration
         self.clean = False
 
-    def run(self):
+    def execute(self):
         cfg = self.conf
 
         if 'collect' in cfg[self.backend_section] and \

--- a/mordred/task_enrich.py
+++ b/mordred/task_enrich.py
@@ -28,6 +28,7 @@ import time
 from grimoire_elk.arthur import (do_studies, enrich_backend, refresh_projects,
                                  refresh_identities)
 from mordred.task import Task
+from mordred.error import DataEnrichmentError
 
 
 
@@ -90,8 +91,10 @@ class TaskEnrich(Task):
                                 author_id=None,
                                 author_uuid=None,
                                 filter_raw=filter_raw)
-            except KeyError as e:
-                logger.exception(e)
+            except:
+                logger.error("Something went wrong producing enriched data for %s . " \
+                             "Using the backend_args: %s " % (self.backend_name, str(backend_args)))
+                raise DataEnrichmentError('Failed to produce enriched data for %s' % self.backend_name)
 
         time.sleep(5)  # Safety sleep tp avoid too quick execution
 

--- a/mordred/task_enrich.py
+++ b/mordred/task_enrich.py
@@ -127,7 +127,7 @@ class TaskEnrich(Task):
         enrich_backend = self._get_enrich_backend()
         do_studies(enrich_backend)
 
-    def run(self):
+    def execute(self):
         if 'enrich' in self.conf[self.backend_section] and \
             self.conf[self.backend_section]['enrich'] == False:
             logging.info('%s enrich disabled', self.backend_section)

--- a/mordred/task_identities.py
+++ b/mordred/task_identities.py
@@ -62,7 +62,13 @@ class TaskIdentitiesCollection(Task):
         code = Init(**self.sh_kwargs).run(self.db_sh)
 
         if not self.backend_section:
-            logger.error ("Backend not configured in TaskIdentitiesCollection.")
+            logger.error ("Backend not configured in TaskIdentitiesCollection %s", self.backend_section)
+            return
+
+        backend_conf = self.conf[self.backend_section]
+
+        if 'collect' in backend_conf and not backend_conf['collect']:
+            logger.error ("Don't load ids from a backend without collection %s", self.backend_section)
             return
 
         if self.load_ids:

--- a/mordred/task_identities.py
+++ b/mordred/task_identities.py
@@ -55,7 +55,7 @@ class TaskIdentitiesCollection(Task):
                         'database': self.db_sh, 'host': self.db_host,
                         'port': None}
 
-    def run(self):
+    def execute(self):
 
         #FIXME this should be called just once
         # code = 0 when command success
@@ -87,7 +87,7 @@ class TaskIdentitiesInit(Task):
     def is_backend_task(self):
         return False
 
-    def run(self):
+    def execute(self):
 
         # code = 0 when command success
         code = Init(**self.sh_kwargs).run(self.db_sh)
@@ -142,7 +142,7 @@ class TaskIdentitiesMerge(Task):
                     uuids.append(p.uuid)
         return uuids
 
-    def run(self):
+    def execute(self):
         if self.unify:
             for algo in self.conf['sh_matching']:
                 kwargs = {'matching':algo, 'fast_matching':True}

--- a/mordred/task_manager.py
+++ b/mordred/task_manager.py
@@ -24,6 +24,7 @@
 
 import logging
 import threading
+import sys
 import time
 
 from grimoire_elk.arthur import get_ocean_backend
@@ -40,7 +41,7 @@ class TasksManager(threading.Thread):
 
     """
 
-    def __init__(self, tasks_cls, backend_name, repos, stopper, conf, timer = 0):
+    def __init__(self, tasks_cls, backend_name, repos, stopper, conf, communication_queue, timer = 0):
         """
         :tasks_cls : tasks classes to be executed using the backend
         :backend_name: perceval backend name
@@ -55,6 +56,7 @@ class TasksManager(threading.Thread):
         self.repos = repos
         self.stopper = stopper  # To stop the thread from parent
         self.timer = timer
+        self.queue = communication_queue
 
     def add_task(self, task):
         self.tasks.append(task)
@@ -84,7 +86,9 @@ class TasksManager(threading.Thread):
                 time.sleep(self.timer)
 
             for task in self.tasks:
-                task.run()
+                try:
+                    task.run()
+                except:
+                    self.queue.put(sys.exc_info())
 
         logger.debug('Exiting Task Manager thread %s', self.backend_name)
-

--- a/mordred/task_manager.py
+++ b/mordred/task_manager.py
@@ -87,7 +87,7 @@ class TasksManager(threading.Thread):
 
             for task in self.tasks:
                 try:
-                    task.run()
+                    task.execute()
                 except:
                     self.queue.put(sys.exc_info())
 

--- a/mordred/task_panels.py
+++ b/mordred/task_panels.py
@@ -170,7 +170,7 @@ class TaskPanels(Task):
             self.__create_alias(es_enrich_url, index_enrich, real_alias)
 
 
-    def run(self):
+    def execute(self):
         # Create the aliases
         self.__create_aliases()
         # Create the commons panels
@@ -282,7 +282,7 @@ class TaskPanelsMenu(Task):
 
         return omenu
 
-    def run(self):
+    def execute(self):
         # Create the panels menu
         menu = self.__get_dash_menu()
         # Remove the current menu and create the new one

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -59,7 +59,7 @@ class TestTask(unittest.TestCase):
         """Test whether the Task could be run"""
         morderer = Mordred(CONF_FILE)
         task = Task(morderer.conf)
-        self.assertEqual(task.run(), None)
+        self.assertEqual(task.execute(), None)
 
     def test_compose_p2o_params(self):
         """Test whether p2o params are built correctly for a backend and a repository"""


### PR DESCRIPTION
Previous implementation was not raising correctly the exceptions, due to there was not method to control the exceptions launched from the mother/father process. 

How to reproduce the error?
- included this mbox data source in .json file
```
	    "mbox":[
	    	"/home/luis/repos/mordred/mboxes"
	    ]
```
- executed with update mode
- monitored the number of threads
```
watch -n1 "ps huH p `ps aux|grep mordred|grep python|awk {'print $2'}`"
```
- while the error is printed in the terminal were mordred was executed, the error is not logged and one of the threads dies


Current changes allow threads to share exceptions using a queue, so the main process can wait and read if any exception was raised and needs to be addressed.

The main process does not wait and check always, in this case the exception is raised from the thread but the traceback is not printed, as this is something done by the parent. This is something to be improved.

