### PR TITLE
Add github.py library to deal with Github files

### DIFF
--- a/mordred/error.py
+++ b/mordred/error.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Luis Cañas-Díaz <lcanas@bitergia.com>
+
+class DataCollectionError(Exception):
+    """Exception raise for error calling feed_backend method
+    """
+    def __init__(self, expression):
+        self.expression = expression
+
+class ElasticSearchError(Exception):
+    """Exception raised for errors in the list of backends
+    """
+    def __init__(self, expression):
+        self.expression = expression
+
+class DataEnrichmentError(Exception):
+    """Exception raised for error calling the enrich_backend method
+    """
+    def __init__(self, expression):
+        self.expression = expression
+
+class ConfigError(Exception):
+    """Exception raised for errors in the configuration file.
+
+    Attributes:
+        expression -- input expression in which the error occurred
+        message -- explanation of the error
+    """
+    def __init__(self, expression, message):
+        self.expression = expression
+        self.message = message
+
+class GithubFileNotFound(Exception):
+    """Exception raised when getting a 404 from github
+    """
+    def __init__(self, message):
+        self.message = message

--- a/mordred/github.py
+++ b/mordred/github.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors:
+#     Luis Cañas-Díaz <lcanas@bitergia.com>
+#
+
+import logging
+import urllib.request
+
+from mordred.error import GithubFileNotFound
+
+logger = logging.getLogger(__name__)
+
+class Github:
+
+    def __init__(self, token):
+        self.token = token
+
+    def __check_looks_like_uri(self, uri):
+        """Checks the URI looks like a RAW uri in github:
+
+        - 'https://raw.githubusercontent.com/github/hubot/master/README.md'
+        - 'https://github.com/github/hubot/raw/master/README.md'
+
+        :param uri: uri of the file
+        """
+        if uri.split('/')[2] == 'raw.githubusercontent.com':
+            return True
+        elif uri.split('/')[2] == 'github.com':
+            if uri.split('/')[5] == 'raw':
+                return True
+        else:
+            raise GithubFileNotFound('URI %s is not a valid link to a raw file in Github' % uri)
+
+    def read_file_from_uri(self, uri):
+        """Reads the file from Github
+
+        :param uri: URI of the Github raw File
+
+        :returns: UTF-8 text with the content
+        """
+        logger.debug("Reading %s" % (uri))
+
+        self.__check_looks_like_uri(uri)
+
+        try:
+            req = urllib.request.Request(uri)
+            req.add_header('Authorization', 'token %s' % self.token)
+            r = urllib.request.urlopen(req)
+        except urllib.error.HTTPError as err:
+            if err.code == 404:
+                raise GithubFileNotFound('File %s is not available. Check the URL to ensure it really exists' % uri)
+            else:
+                raise
+
+        return r.read().decode("utf-8")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Luis Cañas-Díaz <lcanas@bitergia.com>
+#
+
+
+import sys
+import unittest
+
+
+# Hack to make sure that tests import the right packages
+# due to setuptools behaviour
+sys.path.insert(0, '..')
+
+import configparser
+
+from mordred.error import GithubFileNotFound
+from mordred.github import Github
+
+CONF_FILE = 'test.cfg'
+
+class TestGithub(unittest.TestCase):
+    """Task tests"""
+
+    def test_read_file(self):
+        config = configparser.ConfigParser()
+        config.read(CONF_FILE)
+
+        uri = 'https://github.com/grimoirelab/GrimoireELK/blob/master/README.md'
+
+        token = config.get('general', 'github_token')
+
+        gh = Github(token)
+
+        self.assertIsInstance(gh.read_file_from_uri(uri), str)
+        self.assertTrue(len(gh.read_file_from_uri(uri)) > 0)
+
+        uri = 'https://github.com/grimoirelab/doesnotexist/blob/master/README.md'
+        self.assertRaises(GithubFileNotFound, gh.read_file_from_uri, uri)
+
+        uri = 'https://twitter.com/bitergia'
+        self.assertRaises(GithubFileNotFound, gh.read_file_from_uri, uri)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
Github class will allow us to read files from Github using the token to access to private content. Future versions will also push content.

Future versions of Mordred will deal with Github files, some examples:
- reading identity files
- reading project files
- updating project files based on a Github organization and pushing its content

This is why this code is being added. I'm using it a development feature and I wanted to submit it asap so @zhquan can start adding tests to the extension of this library he worked on a weeks ago. See #16 

In order to test it, you'll need a parameter named 'github_token' under the 'general' section of the test.cfg file.