### PR TITLE
Install pandas package in the Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN pip3 install requests
 RUN pip3 install sqlalchemy
 
 # sortinghat needs pandas
-# RUN pip3 install pandas # it crashes so we use the .deb
+RUN pip3 install pandas
 
 RUN echo "${DEPLOY_USER}    ALL=NOPASSWD: ALL" >> /etc/sudoers
 


### PR DESCRIPTION
In order to save time, it's better to have pandas already installed in the image than installing it in the stage phase, as the compilation takes about 5 minutes.